### PR TITLE
[Bugfix]: Fix missleading docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ registerBlockType('vermilion/post-selector', {
           
             <PostSelector
               onPostSelect={post => {
-                attributes.posts.push(post);
-                setAttributes({ posts: [...attributes.posts] });
+                const updatedPosts = [...attributes.posts, post];
+                setAttributes({ posts: updatedPosts });
               }}
               posts={attributes.posts}
               onChange={newValue => {


### PR DESCRIPTION
I've just updated your docs, cz I had some side effects with the examples code. You should never directly update the `attributes` in gutenberg.

BTW: Thanks for the great component!